### PR TITLE
Bugfix for Kepco IOC simulation mode

### DIFF
--- a/iocs/simulator/iocBoot/iockepco_sim/st.cmd
+++ b/iocs/simulator/iocBoot/iockepco_sim/st.cmd
@@ -20,7 +20,7 @@ drvAsynIPPortConfigure ("PS1", "127.0.0.1:9999")
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load record instances
-dbLoadRecords("$(TOP)/../../db/kepco.db","P=$(MYPVPREFIX)KEPCOSIM:, PORT=PS1")
+dbLoadRecords("$(TOP)/../../db/kepco.db","P=$(MYPVPREFIX)KEPCOSIM:, PORT=PS1, DISABLE=$(DISABLE=0),RECSIM=$(RECSIM=0)")
 
 < $(IOCSTARTUP)/preiocinit.cmd
 

--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -4,13 +4,14 @@ record(bo, "$(P)SIM")
     field(DTYP, "Soft Channel")
     field(ZNAM, "NO")
     field(ONAM, "YES")
+	field(VAL, "$(RECSIM=0)")
 }
 
 record(bo, "$(P)DISABLE") 
 {
     field(DESC, "Disable comms")
     field(PINI, "YES")
-    field(VAL, "0")
+    field(VAL, "$(DISABLE=0)")
     field(OMSL, "supervisory")
     field(ZNAM, "COMMS ENABLED")
     field(ONAM, "COMMS DISABLED")


### PR DESCRIPTION
### Description of work

The Kepco IOC should now start successfully in simulation mode if that option is chosen in the gui.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1938

### Acceptance criteria

*List the acceptance criteria for the PR*

- [ ] The Kepco IOC starts successfully in simulation mode if that option is chosen in the GUI.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Are the PVs named according to the [naming standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
- [x] Have suitable [disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records) been added?
- [x] Have suitable [simulation records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation) been added?
- [ ] Have the [finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches) been applied?
- [ ] Is there an [emulator](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Emulating-Devices) for the device?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] Does the IOC respond correctly both in full and simulation mode, where it's possible to test both?
- [x] If there are multiple _0n IOCs, do they run correctly?

### Final steps

- [x] Reviewer has updated the submodule in the main EPICS repo? See **Reviewing work for the subModules of EPICS** in the [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section