### PR TITLE
Ticket4855 muon zero field controller

### DIFF
--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -83,6 +83,8 @@ record(ai, "$(P)CURRENT:SP:RBV")
     field(SDIS, "$(P)DISABLE")
     info(INTEREST, "HIGH")
     info(archive, "VAL")
+    
+    field(FLNK, "$(P)CURRENT:SP:RBV")
 }
 
 record(ao, "$(P)CURRENT:SP") 
@@ -147,6 +149,8 @@ record(ao, "$(P)VOLTAGE:SP")
     field(SDIS, "$(P)DISABLE")
     info(INTEREST, "HIGH")
     info(archive, "VAL")
+    
+    field(FLNK, "$(P)VOLTAGE:SP:RBV")
 }
 
 record(bi, "$(P)OUTPUTMODE") 
@@ -171,6 +175,8 @@ record(bo, "$(P)OUTPUTMODE:SP")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:OUTPUTMODE:SP")
     field(SDIS, "$(P)DISABLE")
+    
+    field(FLNK, "$(P)OUTPUTMODE")
 }
 
 alias("$(P)OUTPUTMODE", "$(P)OUTPUTMODE:SP:RBV")
@@ -198,6 +204,8 @@ record(bo, "$(P)OUTPUTSTATUS:SP")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:OUTPUTSTATUS:SP")
     field(SDIS, "$(P)DISABLE")
+    
+    field(FLNK, "$(P)OUTPUTSTATUS")
 }
 
 alias("$(P)OUTPUTSTATUS", "$(P)OUTPUTSTATUS:SP:RBV")

--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -70,10 +70,19 @@ record(ai, "$(P)CURRENT")
     info(archive, "VAL")
 }
 
+# Scan CURRENT:SP:RBV from here allows us to FLNK to CURRENT:SP:RBV if we need to trigger
+# an extra update. These extra updates are only triggered in recsim mode - in normal mode we push
+# an update from the protocol file whenever a new SP is sent.
+record(bo, "$(P)CURRENT:SP:RBV:_SCAN") 
+{
+    field(SCAN, "1 second")
+    field(FLNK, "$(P)CURRENT:SP:RBV")
+}
+
 record(ai, "$(P)CURRENT:SP:RBV") 
 {
     field(DESC, "Current Setpoint Readback")
-    field(SCAN, "1 second")
+    field(SCAN, "Passive")
     field(DTYP, "stream")
     field(INP,  "@kepco.proto readSetpointCurrent $(PORT)")
     field(PREC, "3")
@@ -90,18 +99,16 @@ record(ao, "$(P)CURRENT:SP")
     field(DESC, "Current Setpoint")
     field(SCAN, "Passive")
     field(DTYP, "stream")
-    field(OUT,  "@kepco.proto writeCurrent $(PORT)")
+    field(OUT,  "@kepco.proto writeCurrent($(P)) $(PORT)")
     field(EGU, "A")
     #field(HOPR, "5.0")
     #field(LOPR, "0.01")    
     field(PREC, "3")
     field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:CURRENT:SP")
+    field(SIOL, "$(P)SIM:CURRENT:SP PP")
     field(SDIS, "$(P)DISABLE")
     info(INTEREST, "HIGH")
     info(archive, "VAL")
-    
-    field(FLNK, "$(P)CURRENT:SP:RBV")
 }
 
 record(ai, "$(P)VOLTAGE") 
@@ -119,10 +126,19 @@ record(ai, "$(P)VOLTAGE")
     info(archive, "VAL")
 }
 
+# Scan VOLTAGE:SP:RBV from here allows us to FLNK to VOLTAGE:SP:RBV if we need to trigger
+# an extra update. These extra updates are only triggered in recsim mode - in normal mode we push
+# an update from the protocol file whenever a new SP is sent.
+record(bo, "$(P)VOLTAGE:SP:RBV:_SCAN") 
+{
+    field(SCAN, "1 second")
+    field(FLNK, "$(P)VOLTAGE:SP:RBV")
+}
+
 record(ai, "$(P)VOLTAGE:SP:RBV") 
 {
     field(DESC, "Voltage setpoint readback")
-    field(SCAN, "1 second")
+    field(SCAN, "Passive")
     field(DTYP, "stream")
     field(INP,  "@kepco.proto readSetpointVoltage $(PORT)")
     field(PREC, "3")
@@ -139,18 +155,16 @@ record(ao, "$(P)VOLTAGE:SP")
     field(DESC, "Voltage setpoint")
     field(SCAN, "Passive")
     field(DTYP, "stream")
-    field(OUT,  "@kepco.proto writeVoltage $(PORT)")
+    field(OUT,  "@kepco.proto writeVoltage($(P)) $(PORT)")
     field(EGU, "V")
     #field(HOPR, "5.0")
     #field(LOPR, "0.01")    
     field(PREC, "3")
     field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:VOLTAGE:SP")
+    field(SIOL, "$(P)SIM:VOLTAGE:SP PP")
     field(SDIS, "$(P)DISABLE")
     info(INTEREST, "HIGH")
     info(archive, "VAL")
-    
-    field(FLNK, "$(P)VOLTAGE:SP:RBV")
 }
 
 record(bi, "$(P)OUTPUTMODE") 
@@ -173,10 +187,10 @@ record(bo, "$(P)OUTPUTMODE:SP")
     field(ZNAM, "VOLTAGE")
     field(ONAM, "CURRENT")
     field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:OUTPUTMODE:SP")
+    field(SIOL, "$(P)SIM:OUTPUTMODE:SP PP")
     field(SDIS, "$(P)DISABLE")
     
-    field(FLNK, "$(P)OUTPUTMODE")
+    field(FLNK, "$(P)OUTPUTMODE.PROC")
 }
 
 alias("$(P)OUTPUTMODE", "$(P)OUTPUTMODE:SP:RBV")
@@ -202,10 +216,10 @@ record(bo, "$(P)OUTPUTSTATUS:SP")
     field(ZNAM, "OFF")
     field(ONAM, "ON")
     field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:OUTPUTSTATUS:SP")
+    field(SIOL, "$(P)SIM:OUTPUTSTATUS:SP PP")
     field(SDIS, "$(P)DISABLE")
     
-    field(FLNK, "$(P)OUTPUTSTATUS")
+    field(FLNK, "$(P)OUTPUTSTATUS.PROC")
 }
 
 alias("$(P)OUTPUTSTATUS", "$(P)OUTPUTSTATUS:SP:RBV")
@@ -216,6 +230,12 @@ record(ai, "$(P)SIM:CURRENT")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
+    
+    # On real device, we update SP:RBV from the protocol whenever a new SP is sent.
+    # This FLNK approximates this behaviour in recsim mode.
+    # The muon ZF system requires fairly quick updates of setpoint readbacks after setting
+    # setpoints, hence this extra complexity.
+    field(FLNK, "$(P)CURRENT:SP:RBV")
 }
 
 alias("$(P)SIM:CURRENT","$(P)SIM:CURRENT:SP")
@@ -244,6 +264,12 @@ record(ai, "$(P)SIM:VOLTAGE")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
+    
+    # On real device, we update SP:RBV from the protocol whenever a new SP is sent.
+    # This FLNK approximates this behaviour in recsim mode.
+    # The muon ZF system requires fairly quick updates of setpoint readbacks after setting
+    # setpoints, hence this extra complexity.
+    field(FLNK, "$(P)VOLTAGE:SP:RBV")
 }
 
 alias("$(P)SIM:VOLTAGE","$(P)SIM:VOLTAGE:SP")

--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -83,8 +83,6 @@ record(ai, "$(P)CURRENT:SP:RBV")
     field(SDIS, "$(P)DISABLE")
     info(INTEREST, "HIGH")
     info(archive, "VAL")
-    
-    field(FLNK, "$(P)CURRENT:SP:RBV")
 }
 
 record(ao, "$(P)CURRENT:SP") 
@@ -102,6 +100,8 @@ record(ao, "$(P)CURRENT:SP")
     field(SDIS, "$(P)DISABLE")
     info(INTEREST, "HIGH")
     info(archive, "VAL")
+    
+    field(FLNK, "$(P)CURRENT:SP:RBV")
 }
 
 record(ai, "$(P)VOLTAGE") 

--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -70,7 +70,7 @@ record(ai, "$(P)CURRENT")
     info(archive, "VAL")
 }
 
-# Scan CURRENT:SP:RBV from here allows us to FLNK to CURRENT:SP:RBV if we need to trigger
+# Scan from here allows us to FLNK to readback if we need to trigger
 # an extra update. These extra updates are only triggered in recsim mode - in normal mode we push
 # an update from the protocol file whenever a new SP is sent.
 record(bo, "$(P)CURRENT:SP:RBV:_SCAN") 
@@ -126,7 +126,7 @@ record(ai, "$(P)VOLTAGE")
     info(archive, "VAL")
 }
 
-# Scan VOLTAGE:SP:RBV from here allows us to FLNK to VOLTAGE:SP:RBV if we need to trigger
+# Scan from here allows us to FLNK to readback if we need to trigger
 # an extra update. These extra updates are only triggered in recsim mode - in normal mode we push
 # an update from the protocol file whenever a new SP is sent.
 record(bo, "$(P)VOLTAGE:SP:RBV:_SCAN") 
@@ -167,9 +167,18 @@ record(ao, "$(P)VOLTAGE:SP")
     info(archive, "VAL")
 }
 
-record(bi, "$(P)OUTPUTMODE") 
+# Scan from here allows us to FLNK to readback if we need to trigger
+# an extra update. These extra updates are only triggered in recsim mode - in normal mode we push
+# an update from the protocol file whenever a new SP is sent.
+record(bo, "$(P)OUTPUTMODE:_SCAN") 
 {
     field(SCAN, "1 second")
+    field(FLNK, "$(P)OUTPUTMODE")
+}
+
+record(bi, "$(P)OUTPUTMODE") 
+{
+    field(SCAN, "Passive")
     field(DTYP, "stream")
     field(INP,  "@kepco.proto readOutputMode $(PORT)")
     field(ZNAM, "VOLTAGE")
@@ -183,21 +192,29 @@ record(bo, "$(P)OUTPUTMODE:SP")
 {
     field(SCAN, "Passive")
     field(DTYP, "stream")
-    field(OUT,  "@kepco.proto setOutputMode $(PORT)")
+    field(OUT,  "@kepco.proto setOutputMode($(P)) $(PORT)")
     field(ZNAM, "VOLTAGE")
     field(ONAM, "CURRENT")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:OUTPUTMODE:SP PP")
     field(SDIS, "$(P)DISABLE")
-    
-    field(FLNK, "$(P)OUTPUTMODE.PROC")
 }
 
 alias("$(P)OUTPUTMODE", "$(P)OUTPUTMODE:SP:RBV")
 
-record(bi, "$(P)OUTPUTSTATUS") 
+
+# Scan from here allows us to FLNK to readback if we need to trigger
+# an extra update. These extra updates are only triggered in recsim mode - in normal mode we push
+# an update from the protocol file whenever a new SP is sent.
+record(bo, "$(P)OUTPUTSTATUS:_SCAN") 
 {
     field(SCAN, "1 second")
+    field(FLNK, "$(P)OUTPUTSTATUS")
+}
+
+record(bi, "$(P)OUTPUTSTATUS") 
+{
+    field(SCAN, "Passive")
     field(DTYP, "stream")
     field(INP,  "@kepco.proto readOutputStatus $(PORT)")
     field(ZNAM, "OFF")
@@ -212,14 +229,12 @@ record(bo, "$(P)OUTPUTSTATUS:SP")
 {
     field(SCAN, "Passive")
     field(DTYP, "stream")
-    field(OUT,  "@kepco.proto setOutputStatus $(PORT)")
+    field(OUT,  "@kepco.proto setOutputStatus($(P)) $(PORT)")
     field(ZNAM, "OFF")
     field(ONAM, "ON")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:OUTPUTSTATUS:SP PP")
     field(SDIS, "$(P)DISABLE")
-    
-    field(FLNK, "$(P)OUTPUTSTATUS.PROC")
 }
 
 alias("$(P)OUTPUTSTATUS", "$(P)OUTPUTSTATUS:SP:RBV")
@@ -280,6 +295,7 @@ record(bi, "$(P)SIM:OUTPUTMODE")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
+    field(FLNK, "$(P)OUTPUTMODE")
 }
 
 alias("$(P)SIM:OUTPUTMODE","$(P)SIM:OUTPUTMODE:SP")
@@ -290,6 +306,7 @@ record(bi, "$(P)SIM:OUTPUTSTATUS")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")
+    field(FLNK, "$(P)OUTPUTSTATUS")
 }
 
 alias("$(P)SIM:OUTPUTSTATUS","$(P)SIM:OUTPUTSTATUS:SP")

--- a/kepcoApp/protocol/kepco.proto
+++ b/kepcoApp/protocol/kepco.proto
@@ -59,7 +59,7 @@ writeVoltage
     
     # immediately update SP:RBV
     out "VOLT?";
-    in "%(\$VOLTAGE:SP:RBV)f";
+    in "%(\$1VOLTAGE:SP:RBV)f";
     ExtraInput = Ignore;
 }
 
@@ -73,6 +73,11 @@ readOutputMode
 setOutputMode
 {
     out "FUNC:MODE %{VOLT|CURR}";
+    
+    # Immediately update readback
+    out "FUNC:MODE?";
+    in "%(\$1OUTPUTMODE)d";
+    ExtraInput = Ignore;
 }
 
 readOutputStatus
@@ -85,4 +90,9 @@ readOutputStatus
 setOutputStatus
 {
     out "OUTP %{0|1}";
+    
+    # Immediately update readback
+    out "OUTP?";
+    in "%(\$1OUTPUTSTATUS)d";
+    ExtraInput = Ignore;
 }

--- a/kepcoApp/protocol/kepco.proto
+++ b/kepcoApp/protocol/kepco.proto
@@ -34,6 +34,11 @@ readSetpointCurrent {
 writeCurrent 
 {
     out "CURR %f";
+    
+    # immediately update SP:RBV
+    out "CURR?";
+    in "%(\$1CURRENT:SP:RBV)f";
+    ExtraInput = Ignore;
 }
 
 readActualVoltage {
@@ -51,6 +56,11 @@ readSetpointVoltage {
 writeVoltage
 {
     out "VOLT %f";
+    
+    # immediately update SP:RBV
+    out "VOLT?";
+    in "%(\$VOLTAGE:SP:RBV)f";
+    ExtraInput = Ignore;
 }
 
 readOutputMode


### PR DESCRIPTION
Minor changes to kepco to make it quicker to respond to setpoint changes. These faster updates are needed by the muon zero field controller. Functionality should be unchanged other than readbacks updating a little faster.

https://github.com/ISISComputingGroup/IBEX/issues/4855

