### PR TITLE
Ticket3185 remote mode reliability

### DIFF
--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -53,10 +53,19 @@ record(stringin, "$(P)RST")
 record(stringin, "$(P)RSTRSND") {
     field(DESC, "Reset and resend params to power supply")
     field(DTYP, "stream")
-    field(INP, "@kepco.proto resetWait($(P)) $(PORT) ")
+    field(INP, "@kepco.proto RST $(PORT)")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:RSTRSND")
     field(SDIS, "$(P)DISABLE")
+    field(FLNK, "$(P)RSND.PROC")
+}
+
+record(fanout, "$(P)RSND") {
+    field(LNK1, "$(P)CURRENT:SP.PROC")
+    field(LNK2, "$(P)VOLTAGE:SP.PROC")
+    field(LNK3, "$(P)OUTPUTSTATUS:SP.PROC")
+    field(LNK4, "$(P)OUTPUTMODE:SP.PROC")
+    field(SELM, "All")
 }
 
 record(calcout, "$(P)RSTRSND:ON_START") {

--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -29,6 +29,16 @@ record(stringin, "$(P)IDN")
     field(SDIS, "$(P)DISABLE")
 }
 
+record(ai, "$(P)FIRMWARE") {
+    field(DESC, "The firmware version of the KEPCO")
+    field(DTYP, "stream")
+    field(INP,  "@kepco.proto getFirmware $(PORT)")
+    field(PINI, "YES")
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:FIRMWARE")
+    field(SDIS, "$(P)DISABLE")
+}
+
 record(stringin, "$(P)RST")
 {
     field(DESC, "Reset the power supply")
@@ -296,6 +306,12 @@ record(bo, "$(P)SIM:REMOTE")
 }
 
 record(stringin, "$(P)SIM:IDN")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+record(stringin, "$(P)SIM:FIRMWARE")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")

--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -55,7 +55,7 @@ record(calcout, "$(P)RSTRSND:ON_START") {
     field(INPA, "$(ON_START)")
     field(CALC, "A == 1")
     field(OOPT, "When Non-zero")
-    field(OUT, "$(P)RSTRSND")
+    field(OUT, "$(P)RSTRSND.PROC")
 }
 
 record(calcout, "$(P)REM:ON_START") {
@@ -64,7 +64,7 @@ record(calcout, "$(P)REM:ON_START") {
     field(INPA, "$(ON_START)")
     field(CALC, "A == 2")
     field(OOPT, "When Non-zero")
-    field(OUT, "$(P)REMOTE")
+    field(OUT, "$(P)REMOTE.PROC")
 }
 
 
@@ -78,8 +78,6 @@ record(bo, "$(P)REMOTE")
     field(ZNAM, "OFF")
     field(ONAM, "ON")
     field(VAL, "1")
-    field(PINI, "$(P)REM:AVAILABLE")
-    field(FLNK, "$(P)REMOTE:GET")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:REMOTE")
     field(SDIS, "$(P)DISABLE")
@@ -139,6 +137,7 @@ record(ao, "$(P)CURRENT:SP")
     field(SDIS, "$(P)DISABLE")
     info(INTEREST, "HIGH")
     info(archive, "5.0 VAL")
+    info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)VOLTAGE") 
@@ -195,6 +194,7 @@ record(ao, "$(P)VOLTAGE:SP")
     field(SDIS, "$(P)DISABLE")
     info(INTEREST, "HIGH")
     info(archive, "5.0 VAL")
+    info(autosaveFields, "VAL")
 }
 
 # Scan from here allows us to FLNK to readback if we need to trigger
@@ -228,6 +228,7 @@ record(bo, "$(P)OUTPUTMODE:SP")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:OUTPUTMODE:SP PP")
     field(SDIS, "$(P)DISABLE")
+    info(autosaveFields, "VAL")
 }
 
 alias("$(P)OUTPUTMODE", "$(P)OUTPUTMODE:SP:RBV")
@@ -265,6 +266,7 @@ record(bo, "$(P)OUTPUTSTATUS:SP")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:OUTPUTSTATUS:SP PP")
     field(SDIS, "$(P)DISABLE")
+    info(autosaveFields, "VAL")
 }
 
 alias("$(P)OUTPUTSTATUS", "$(P)OUTPUTSTATUS:SP:RBV")
@@ -288,12 +290,6 @@ alias("$(P)SIM:CURRENT","$(P)SIM:CURRENT:SP")
 alias("$(P)SIM:CURRENT","$(P)SIM:CURRENT:SP:RBV")
 
 record(bo, "$(P)SIM:REMOTE")
-{
-    field(SCAN, "Passive")
-    field(DTYP, "Soft Channel")
-}
-
-record(bi, "$(P)SIM:REMOTE:GET")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")

--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -37,6 +37,7 @@ record(ai, "$(P)FIRMWARE") {
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:FIRMWARE")
     field(SDIS, "$(P)DISABLE")
+    field(FLNK, "$(P)RSTRSND:ON_START.PROC")
 }
 
 record(stringin, "$(P)RST")
@@ -44,7 +45,6 @@ record(stringin, "$(P)RST")
     field(DESC, "Reset the power supply")
     field(DTYP, "stream")
     field(INP,  "@kepco.proto RST $(PORT)")
-    field(PINI, "$(RESET=NO)")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:RST")
     field(SDIS, "$(P)DISABLE")
@@ -61,24 +61,12 @@ record(stringin, "$(P)RSTRSND") {
 
 record(calcout, "$(P)RSTRSND:ON_START") {
     field(DESC, "Trigger RSTRSND on start")
-    field(PINI, "YES")
-    field(INPA, "$(ON_START=0)")
+    field(INPA, "$(RESET_ON_START)")
     field(INPB, "$(P)FIRMWARE")
-    field(CALC, "(A == 0 && B <= 2.0) || A == 1")
+    field(CALC, "(A == 1 && B <= 2.0) || A == 2")
     field(OOPT, "When Non-zero")
     field(OUT, "$(P)RSTRSND.PROC")
 }
-
-record(calcout, "$(P)REM:ON_START") {
-    field(DESC, "Trigger REMOTE on start")
-    field(PINI, "YES")
-    field(INPA, "$(ON_START=0)")
-    field(INPB, "$(P)FIRMWARE")
-    field(CALC, "(A == 0 && B > 2.0) || A == 2")
-    field(OOPT, "When Non-zero")
-    field(OUT, "$(P)REMOTE.PROC")
-}
-
 
 record(bo, "$(P)REMOTE") 
 {

--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -62,8 +62,9 @@ record(stringin, "$(P)RSTRSND") {
 record(calcout, "$(P)RSTRSND:ON_START") {
     field(DESC, "Trigger RSTRSND on start")
     field(PINI, "YES")
-    field(INPA, "$(ON_START)")
-    field(CALC, "A == 1")
+    field(INPA, "$(ON_START=0)")
+    field(INPB, "$(P)FIRMWARE")
+    field(CALC, "(A == 0 && B <= 2.0) || A == 1")
     field(OOPT, "When Non-zero")
     field(OUT, "$(P)RSTRSND.PROC")
 }
@@ -71,8 +72,9 @@ record(calcout, "$(P)RSTRSND:ON_START") {
 record(calcout, "$(P)REM:ON_START") {
     field(DESC, "Trigger REMOTE on start")
     field(PINI, "YES")
-    field(INPA, "$(ON_START)")
-    field(CALC, "A == 2")
+    field(INPA, "$(ON_START=0)")
+    field(INPB, "$(P)FIRMWARE")
+    field(CALC, "(A == 0 && B > 2.0) || A == 2")
     field(OOPT, "When Non-zero")
     field(OUT, "$(P)REMOTE.PROC")
 }

--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -53,7 +53,7 @@ record(stringin, "$(P)RST")
 record(stringin, "$(P)RSTRSND") {
     field(DESC, "Reset and resend setpoints to kepco")
     field(DTYP, "stream")
-    field(INP, "@kepco.proto resetWait($(P)) $(PORT) ") # Reset and resend commands via proto so we can wait for reset to complete
+    field(INP, "@kepco.proto resetWaitResendSPs($(P)) $(PORT) ") # Reset and resend commands via proto so we can wait for reset to complete
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:RSTRSND")
     field(SDIS, "$(P)DISABLE")

--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -59,14 +59,6 @@ record(stringin, "$(P)RSTRSND") {
     field(SDIS, "$(P)DISABLE")
 }
 
-record(fanout, "$(P)RSND") {
-    field(LNK1, "$(P)CURRENT:SP.PROC")
-    field(LNK2, "$(P)VOLTAGE:SP.PROC")
-    field(LNK3, "$(P)OUTPUTSTATUS:SP.PROC")
-    field(LNK4, "$(P)OUTPUTMODE:SP.PROC")
-    field(SELM, "All")
-}
-
 record(calcout, "$(P)RSTRSND:ON_START") {
     field(DESC, "Trigger RSTRSND on start")
     field(INPA, "$(RESET_ON_START)")

--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -51,13 +51,12 @@ record(stringin, "$(P)RST")
 } 
 
 record(stringin, "$(P)RSTRSND") {
-    field(DESC, "Reset and resend params to power supply")
+    field(DESC, "Reset and resend setpoints to kepco")
     field(DTYP, "stream")
-    field(INP, "@kepco.proto RST $(PORT)")
+    field(INP, "@kepco.proto resetWait($(P)) $(PORT) ") # Reset and resend commands via proto so we can wait for reset to complete
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:RSTRSND")
     field(SDIS, "$(P)DISABLE")
-    field(FLNK, "$(P)RSND.PROC")
 }
 
 record(fanout, "$(P)RSND") {

--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -31,7 +31,7 @@ record(stringin, "$(P)IDN")
 
 record(stringin, "$(P)RST")
 {
-    field(DESC, "SCPI identification string")
+    field(DESC, "Reset the power supply")
     field(DTYP, "stream")
     field(INP,  "@kepco.proto RST $(PORT)")
     field(PINI, "$(RESET=NO)")
@@ -40,9 +40,37 @@ record(stringin, "$(P)RST")
     field(SDIS, "$(P)DISABLE")
 } 
 
+# records to set the kepco into remote mode or reset on ioc start
+
+record(bi, "$(P)REM:AVAILABLE") {
+    field(DESC, "True if SYST:REM command available")
+    field(SCAN, "Passive")
+    field(ZNAM, "NO")
+    field(ONAM, "YES")
+    field(VAL, "1")
+    field(PINI, "YES")
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:REM:AVAILABLE")
+    field(SDIS, "$(P)DISABLE")
+}
+
+record(bi, "$(P)REMOTE:GET") {
+    field(DESC, "Get if the unit is in remote mode")
+    field(SCAN, "Passive")
+    field(DTYP, "stream")
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+    field(OUT,  "@kepco.proto getRemote $(PORT)")
+    field(VAL, "0")
+    field(PINI, "$(P)REM:AVAILABLE")
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:REMOTE:GET")
+    field(SDIS, "$(P)DISABLE")
+}
+
 record(bo, "$(P)REMOTE") 
 {
-    #Must be put into remote before PSU related commands sent
+    #Must be put into remote or reset before PSU related commands sent
     field(DESC, "Put the unit into remote mode")
     field(SCAN, "Passive")
     field(DTYP, "stream")
@@ -50,6 +78,8 @@ record(bo, "$(P)REMOTE")
     field(ZNAM, "OFF")
     field(ONAM, "ON")
     field(VAL, "1")
+    field(PINI, "$(P)REM:AVAILABLE")
+    field(FLNK, "$(P)REMOTE:GET")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:REMOTE")
     field(SDIS, "$(P)DISABLE")
@@ -258,6 +288,12 @@ alias("$(P)SIM:CURRENT","$(P)SIM:CURRENT:SP")
 alias("$(P)SIM:CURRENT","$(P)SIM:CURRENT:SP:RBV")
 
 record(bo, "$(P)SIM:REMOTE")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+record(bi, "$(P)SIM:REMOTE:GET")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")

--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -40,33 +40,33 @@ record(stringin, "$(P)RST")
     field(SDIS, "$(P)DISABLE")
 } 
 
-# records to set the kepco into remote mode or reset on ioc start
-
-record(bi, "$(P)REM:AVAILABLE") {
-    field(DESC, "True if SYST:REM command available")
-    field(SCAN, "Passive")
-    field(ZNAM, "NO")
-    field(ONAM, "YES")
-    field(VAL, "1")
-    field(PINI, "YES")
-    field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:REM:AVAILABLE")
-    field(SDIS, "$(P)DISABLE")
-}
-
-record(bi, "$(P)REMOTE:GET") {
-    field(DESC, "Get if the unit is in remote mode")
-    field(SCAN, "Passive")
+record(stringin, "$(P)RSTRSND") {
+    field(DESC, "Reset and resend params to power supply")
     field(DTYP, "stream")
-    field(ZNAM, "OFF")
-    field(ONAM, "ON")
-    field(OUT,  "@kepco.proto getRemote $(PORT)")
-    field(VAL, "0")
-    field(PINI, "$(P)REM:AVAILABLE")
+    field(INP, "@kepco.proto resetWait($(P)) $(PORT) ")
     field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:REMOTE:GET")
+    field(SIOL, "$(P)SIM:RSTRSND")
     field(SDIS, "$(P)DISABLE")
 }
+
+record(calcout, "$(P)RSTRSND:ON_START") {
+    field(DESC, "Trigger RSTRSND on start")
+    field(PINI, "YES")
+    field(INPA, "$(ON_START)")
+    field(CALC, "A == 1")
+    field(OOPT, "When Non-zero")
+    field(OUT, "$(P)RSTRSND")
+}
+
+record(calcout, "$(P)REM:ON_START") {
+    field(DESC, "Trigger REMOTE on start")
+    field(PINI, "YES")
+    field(INPA, "$(ON_START)")
+    field(CALC, "A == 2")
+    field(OOPT, "When Non-zero")
+    field(OUT, "$(P)REMOTE")
+}
+
 
 record(bo, "$(P)REMOTE") 
 {
@@ -306,6 +306,12 @@ record(stringin, "$(P)SIM:IDN")
 }
 
 record(stringin, "$(P)SIM:RST")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+}
+
+record(stringin, "$(P)SIM:RSTRSND")
 {
     field(SCAN, "Passive")
     field(DTYP, "Soft Channel")

--- a/kepcoApp/protocol/kepco.proto
+++ b/kepcoApp/protocol/kepco.proto
@@ -129,26 +129,22 @@ resetWait {
     # immediately update SP:RBV
     out "VOLT?";
     in "%(\$1VOLTAGE:SP:RBV)f";
-    ExtraInput = Ignore;
 
     # Communicate current
     out "CURR %(\$1CURRENT:SP.VAL)f";
     # immediately update SP:RBV
     out "CURR?";
     in "%(\$1CURRENT:SP:RBV)f";
-    ExtraInput = Ignore;
 
     # Communicate output mode
     out "FUNC:MODE %(\$1OUTPUTMODE:SP.VAL){VOLT|CURR}";
     # Immediately update readback
     out "FUNC:MODE?";
     in "%(\$1OUTPUTMODE){VOLT|CURR}";
-    ExtraInput = Ignore;
 
     # Communicate output status
     out "OUTP %(\$1OUTPUTSTATUS:SP.VAL){0|1}";
     # Immediately update readback
     out "OUTP?";
     in "%(\$1OUTPUTSTATUS){0|1}";
-    ExtraInput = Ignore;
 }

--- a/kepcoApp/protocol/kepco.proto
+++ b/kepcoApp/protocol/kepco.proto
@@ -23,12 +23,6 @@ setRemote
     out "SYST:REM %{0|1}";
 }
 
-getRemote
-{
-    out "SYST:REM?";
-    in "%{0|1}";
-}
-
 readActualCurrent {
     out "MEAS:CURR?";
     in "%f";
@@ -126,7 +120,7 @@ RST
     out "*RST";
 }
 
-resetWait {
+resetWaitResendSPs {
     # Reset 
     RST;
 

--- a/kepcoApp/protocol/kepco.proto
+++ b/kepcoApp/protocol/kepco.proto
@@ -8,6 +8,15 @@ getIDN {
     ExtraInput = Ignore;
 }
 
+getFirmware {
+    out "*IDN?";
+    # Format: Manufacturer, Model, Serial Number, Main revision-Flash revision
+    # For example: KEPCO, BIT4886-6 200-20, A38621 11/10/98, 1.81-1.81.
+    # Regex gets everything after the last space, comma or dash
+    in "%*/(.*[, -])+/%f";
+    ExtraInput = Ignore;
+}
+
 setRemote
 {
     #Needs to be done first

--- a/kepcoApp/protocol/kepco.proto
+++ b/kepcoApp/protocol/kepco.proto
@@ -8,20 +8,6 @@ getIDN {
     ExtraInput = Ignore;
 }
 
-RST
-{
-    out "*RST";
-}
-
-resetWait {
-    out "*RST";
-    wait 100;
-    writeCurrent "%(\$1CURRENT:SP.VAL)";
-    writeVoltage "%(\$1VOLTAGE:SP.VAL)";
-    setOutputMode "%(\$1OUTPUTMODE:SP.VAL)";
-    setOutputStatus "%(\$1OUTPUTSTATUS:SP.VAL)";
-}
-
 setRemote
 {
     #Needs to be done first
@@ -46,8 +32,7 @@ readSetpointCurrent {
     ExtraInput = Ignore;
 }
 
-writeCurrent 
-{
+writeCurrent {
     # Set into remote mode in order to communicate current
     out "SYST:REM 1";
 
@@ -72,8 +57,7 @@ readSetpointVoltage {
     ExtraInput = Ignore;
 }
 
-writeVoltage
-{
+writeVoltage {
     # Set into remote mode in order to communicate voltage
     out "SYST:REM 1";
 
@@ -125,5 +109,46 @@ setOutputStatus
     # Immediately update readback
     out "OUTP?";
     in "%(\$1OUTPUTSTATUS)d";
+    ExtraInput = Ignore;
+}
+
+RST
+{
+    out "*RST";
+}
+
+resetWait {
+    # Reset 
+    RST;
+
+    # Wait for reset to complete
+    wait 100;
+
+    # Communicate voltage
+    out "VOLT %(\$1VOLTAGE:SP.VAL)f";
+    # immediately update SP:RBV
+    out "VOLT?";
+    in "%(\$1VOLTAGE:SP:RBV)f";
+    ExtraInput = Ignore;
+
+    # Communicate current
+    out "CURR %(\$1CURRENT:SP.VAL)f";
+    # immediately update SP:RBV
+    out "CURR?";
+    in "%(\$1CURRENT:SP:RBV)f";
+    ExtraInput = Ignore;
+
+    # Communicate output mode
+    out "FUNC:MODE %(\$1OUTPUTMODE:SP.VAL){VOLT|CURR}";
+    # Immediately update readback
+    out "FUNC:MODE?";
+    in "%(\$1OUTPUTMODE){VOLT|CURR}";
+    ExtraInput = Ignore;
+
+    # Communicate output status
+    out "OUTP %(\$1OUTPUTSTATUS:SP.VAL){0|1}";
+    # Immediately update readback
+    out "OUTP?";
+    in "%(\$1OUTPUTSTATUS){0|1}";
     ExtraInput = Ignore;
 }

--- a/kepcoApp/protocol/kepco.proto
+++ b/kepcoApp/protocol/kepco.proto
@@ -19,6 +19,12 @@ setRemote
     out "SYST:REM %{0|1}";
 }
 
+getRemote
+{
+    out "SYST:REM?";
+    in "%{0|1}";
+}
+
 readActualCurrent {
     out "MEAS:CURR?";
     in "%f";

--- a/kepcoApp/protocol/kepco.proto
+++ b/kepcoApp/protocol/kepco.proto
@@ -13,6 +13,15 @@ RST
     out "*RST";
 }
 
+resetWait {
+    out "*RST";
+    wait 100;
+    writeCurrent "%(\$1CURRENT:SP.VAL)";
+    writeVoltage "%(\$1VOLTAGE:SP.VAL)";
+    setOutputMode "%(\$1OUTPUTMODE:SP.VAL)";
+    setOutputStatus "%(\$1OUTPUTSTATUS:SP.VAL)";
+}
+
 setRemote
 {
     #Needs to be done first

--- a/kepcoApp/protocol/kepco.proto
+++ b/kepcoApp/protocol/kepco.proto
@@ -125,3 +125,35 @@ RST
 {
     out "*RST";
 }
+
+resetWait {
+    # Reset 
+    RST;
+
+    # Wait for reset to complete
+    wait 100;
+
+    # Communicate voltage
+    out "VOLT %(\$1VOLTAGE:SP.VAL)f";
+    # immediately update SP:RBV
+    out "VOLT?";
+    in "%(\$1VOLTAGE:SP:RBV)f";
+
+    # Communicate current
+    out "CURR %(\$1CURRENT:SP.VAL)f";
+    # immediately update SP:RBV
+    out "CURR?";
+    in "%(\$1CURRENT:SP:RBV)f";
+
+    # Communicate output mode
+    out "FUNC:MODE %(\$1OUTPUTMODE:SP.VAL){VOLT|CURR}";
+    # Immediately update readback
+    out "FUNC:MODE?";
+    in "%(\$1OUTPUTMODE)d";
+
+    # Communicate output status
+    out "OUTP %(\$1OUTPUTSTATUS:SP.VAL){0|1}";
+    # Immediately update readback
+    out "OUTP?";
+    in "%(\$1OUTPUTSTATUS){0|1}";
+}

--- a/kepcoApp/protocol/kepco.proto
+++ b/kepcoApp/protocol/kepco.proto
@@ -127,6 +127,12 @@ resetWaitResendSPs {
     # Wait for reset to complete
     wait 100;
 
+    # Communicate output mode
+    out "FUNC:MODE %(\$1OUTPUTMODE:SP.VAL){VOLT|CURR}";
+    # Immediately update readback
+    out "FUNC:MODE?";
+    in "%(\$1OUTPUTMODE)d";
+
     # Communicate voltage
     out "VOLT %(\$1VOLTAGE:SP.VAL)f";
     # immediately update SP:RBV
@@ -138,12 +144,6 @@ resetWaitResendSPs {
     # immediately update SP:RBV
     out "CURR?";
     in "%(\$1CURRENT:SP:RBV)f";
-
-    # Communicate output mode
-    out "FUNC:MODE %(\$1OUTPUTMODE:SP.VAL){VOLT|CURR}";
-    # Immediately update readback
-    out "FUNC:MODE?";
-    in "%(\$1OUTPUTMODE)d";
 
     # Communicate output status
     out "OUTP %(\$1OUTPUTSTATUS:SP.VAL){0|1}";

--- a/kepcoApp/protocol/kepco.proto
+++ b/kepcoApp/protocol/kepco.proto
@@ -125,35 +125,3 @@ RST
 {
     out "*RST";
 }
-
-resetWait {
-    # Reset 
-    RST;
-
-    # Wait for reset to complete
-    wait 100;
-
-    # Communicate voltage
-    out "VOLT %(\$1VOLTAGE:SP.VAL)f";
-    # immediately update SP:RBV
-    out "VOLT?";
-    in "%(\$1VOLTAGE:SP:RBV)f";
-
-    # Communicate current
-    out "CURR %(\$1CURRENT:SP.VAL)f";
-    # immediately update SP:RBV
-    out "CURR?";
-    in "%(\$1CURRENT:SP:RBV)f";
-
-    # Communicate output mode
-    out "FUNC:MODE %(\$1OUTPUTMODE:SP.VAL){VOLT|CURR}";
-    # Immediately update readback
-    out "FUNC:MODE?";
-    in "%(\$1OUTPUTMODE)d";
-
-    # Communicate output status
-    out "OUTP %(\$1OUTPUTSTATUS:SP.VAL){0|1}";
-    # Immediately update readback
-    out "OUTP?";
-    in "%(\$1OUTPUTSTATUS){0|1}";
-}

--- a/kepcoApp/protocol/kepco.proto
+++ b/kepcoApp/protocol/kepco.proto
@@ -149,7 +149,7 @@ resetWait {
     out "FUNC:MODE %(\$1OUTPUTMODE:SP.VAL){VOLT|CURR}";
     # Immediately update readback
     out "FUNC:MODE?";
-    in "%(\$1OUTPUTMODE){VOLT|CURR}";
+    in "%(\$1OUTPUTMODE)d";
 
     # Communicate output status
     out "OUTP %(\$1OUTPUTSTATUS:SP.VAL){0|1}";


### PR DESCRIPTION
### Description of work

- Add ability to get firmware version
- Conditionally reset the kepco and resend parameters on startup
    - Setpoints are autosaved so when the IOC is restarted the values are repopulated in the IOC
    - The `resetWaitResendSPs` proto method reads the autosaved value from the setpoint and resends it to the device
    - The `FIRMWARE` record is processed at initialisation and then forward links to the `RSTRSND:ON_START` record
    - The `RSTRSND:ON_START` record checks if the user has set the macro to "Always reset and resend on start" after which it does so, or if the macro is set to restart conditionally it checks if the firmware is less than or equal to 2 (2 is taken from the various kepco manuals as the earliest manual which has the SYST:REM command) and if it is then the IOC resets the kepco and resends. Alternatively, if the macro is set to 0 (do not reset and resend) then this is not done.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3185

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
