### PR TITLE
Fix bug where KEPCO db sends two setpoints to the device per set

### DIFF
--- a/kepcoApp/Db/kepco_ramping.db
+++ b/kepcoApp/Db/kepco_ramping.db
@@ -8,7 +8,7 @@ record(ao, "$(P)CURRENT:SP")
     field(DTYP, "asynFloat64")
     field(OUT, "@asyn($(READ),0,1)TGT")
 # I/O intr FLNK won't process until we trigger PROC via CA
-    field(FLNK, "$(P)OUT_SP.PROC CA")
+    #field(FLNK, "$(P)OUT_SP.PROC CA")
     field(EGU, "A")
     field(DRVH, $(CURRENT_MAX))
     field(DRVL, "-$(CURRENT_MAX)")

--- a/kepcoApp/Db/kepco_ramping.db
+++ b/kepcoApp/Db/kepco_ramping.db
@@ -7,8 +7,6 @@ record(ao, "$(P)CURRENT:SP")
     field(DESC, "Current setpoint")
     field(DTYP, "asynFloat64")
     field(OUT, "@asyn($(READ),0,1)TGT")
-# I/O intr FLNK won't process until we trigger PROC via CA
-    #field(FLNK, "$(P)OUT_SP.PROC CA")
     field(EGU, "A")
     field(DRVH, $(CURRENT_MAX))
     field(DRVL, "-$(CURRENT_MAX)")


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/6152

To test:

- Confirm only one setpoint sent when writing to CURRENT:SP (Can be done by running new IOCTestFramework tests)