### PR TITLE
Ticket6797 test changes in current range for zf

### DIFF
--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -253,6 +253,14 @@ record(ao, "$(P)FIELD:SP:RBV")
     info(INTEREST, "MEDIUM")
 }
 
+record(longin, "$(P)CURRENT:RANGE") {
+    field(DESC, "The programmed current range")
+    field(EGU, "")
+    field(INP, "@kepco.proto readCurrentRange($(P)) $(PORT)")
+    field(DTYP, "stream")
+    field(SCAN, "Passive")
+}
+
 ### SIMULATION RECORDS ###
 
 record(ai, "$(P)SIM:CURRENT")
@@ -368,4 +376,8 @@ record(seq, "$(P)_SCAN_LOOP") {
     field(DOL5, "1")
     field(DLY5, "0.1")
     field(LNK5, "$(P)OUTPUTSTATUS.PROC")
+
+    field(DOL5, "1")
+    field(DLY5, "0.1")
+    field(LNK5, "$(P)CURRENT:RANGE.PROC")
 }

--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -253,10 +253,22 @@ record(ao, "$(P)FIELD:SP:RBV")
     info(INTEREST, "MEDIUM")
 }
 
-record(longin, "$(P)CURRENT:RANGE") {
+record(mbbi, "$(P)CURRENT:RANGE") {
     field(DESC, "The programmed current range")
-    field(EGU, "")
     field(INP, "@kepco.proto readCurrentRange($(P)) $(PORT)")
+    field(DTYP, "stream")
+    field(SCAN, "Passive")
+
+    field(ONST, "FULL")         field(ONVL, "1")
+    field(FRST, "QUARTER")        field(FRVL, "4")
+}
+
+record(mbbo, "$(P)CURRENT:RANGE:SP") {
+    field(DESC, "The current range setpoint")
+    field(OUT,  "output_link")
+    field(ONST, "FULL")         field(ONVL, "1")
+    field(FRST, "QUARTER")        field(FRVL, "4")
+    field(OUT, "@kepco.proto setCurrentRange($(P)) $(PORT)")
     field(DTYP, "stream")
     field(SCAN, "Passive")
 }

--- a/kepcoApp/Db/kepco.db
+++ b/kepcoApp/Db/kepco.db
@@ -389,7 +389,7 @@ record(seq, "$(P)_SCAN_LOOP") {
     field(DLY5, "0.1")
     field(LNK5, "$(P)OUTPUTSTATUS.PROC")
 
-    field(DOL5, "1")
-    field(DLY5, "0.1")
-    field(LNK5, "$(P)CURRENT:RANGE.PROC")
+    field(DOL6, "1")
+    field(DLY6, "0.1")
+    field(LNK6, "$(P)CURRENT:RANGE.PROC")
 }

--- a/kepcoApp/protocol/kepco.proto
+++ b/kepcoApp/protocol/kepco.proto
@@ -157,3 +157,12 @@ readCurrentRange {
     in "%d";
     ExtraInput = Ignore;
 }
+
+setCurrentRange {
+    out "CURR:RANG %d";
+
+    # Immediately update readback
+    out "CURR:RANG?";
+    in "%(\$1CURRENT:RANGE)d";
+    ExtraInput = Ignore;
+}

--- a/kepcoApp/protocol/kepco.proto
+++ b/kepcoApp/protocol/kepco.proto
@@ -151,3 +151,9 @@ resetWaitResendSPs {
     out "OUTP?";
     in "%(\$1OUTPUTSTATUS){0|1}";
 }
+
+readCurrentRange {
+    out "CURR:RANG?";
+    in "%d";
+    ExtraInput = Ignore;
+}


### PR DESCRIPTION
Add the ability to get and set the current range in order to test the zero-field controller when the current range changes. We need to consider if we want to keep these changes as they have not been used previously, but could be useful in the future.

Ticket for the testing: https://github.com/ISISComputingGroup/IBEX/issues/6797